### PR TITLE
updated to use more recent conda gcc version (7.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - ['g++-6']
-      env:
-        - CC=gcc-6
-        - CXX=g++-6
     - os: osx
       osx_image: xcode9.1
       sudo: false

--- a/recipes/build.sh
+++ b/recipes/build.sh
@@ -4,10 +4,12 @@ set -e # Abort on error
 
 if [[ $(uname) == 'Linux' ]]; then
     if [[ $ARCH -eq 64 ]]; then
-        CC=gcc-6 CXX=g++-6 make -f Makefile.linux64 all install INSTDIR=$PREFIX;
+        make -f Makefile.linux64 all install INSTDIR=$PREFIX CC=$CC CXX=$CXX;
     else
-        CC=gcc-6 CXX=g++-6 make -f Makefile.linux all install INSTDIR=$PREFIX;
+        make -f Makefile.linux all install INSTDIR=$PREFIX CC=$CC CXX=$CXX;
     fi
 else
     make -f Makefile.mac all install INSTDIR=$PREFIX;
 fi
+
+

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -19,9 +19,10 @@ requirements:
   build:
     - python  # [win]
     - vc 14  # [win and (py35 or py36)]
+    - {{ compiler('cxx') }}
   run:
     - vc  # [win and (py35 or py36)]
-
+    
 test:
   commands:
     - test -e $PREFIX/lib/libcsmapi.so  # [linux]


### PR DESCRIPTION
```shell
(base) -bash-4.2$ objdump -s --section .comment $CONDA_PREFIX/lib/libcsmapi.so

/home/krodriguez/linuxconda/lib/libcsmapi.so:     file format elf64-x86-64

Contents of section .comment:
 0000 4743433a 20286372 6f737374 6f6f6c2d  GCC: (crosstool-
 0010 4e472066 61383835 39636229 20372e32  NG fa8859cb) 7.2
 0020 2e3000                               .0.
```

Alternatively, we can use specific versions with something like: 
```
c_compiler_version:    # [linux]
    - 6.5              # [linux]
cxx_compiler_version:  # [linux]
    - 6.5              # [linux]
```


More here: https://conda.io/docs/user-guide/tasks/build-packages/variants.html#compiler-packages